### PR TITLE
feat: support `name`  for output (`options.name`)

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ module.exports.pitch = function(request) {
 	}
 	var workerCompiler = this._compilation.createChildCompiler("worker", outputOptions);
 	workerCompiler.apply(new WebWorkerTemplatePlugin(outputOptions));
-	workerCompiler.apply(new SingleEntryPlugin(this.context, "!!" + request, "main"));
+	workerCompiler.apply(new SingleEntryPlugin(this.context, "!!" + request, query.name || "main"));
 	if(this.options && this.options.worker && this.options.worker.plugins) {
 		this.options.worker.plugins.forEach(function(plugin) {
 			workerCompiler.apply(plugin);


### PR DESCRIPTION
Hi, awesome work with the worker-loader.  I've ran into some issues overriding the worker filename. Supplying a `name` query parameter in the file `require()` or `import` always generates the same filename ("main.js") regardless of my webpack config settings. 

Perhaps I am missing something, but the proposed PR seems to fix it.

``` js
import worker from 'worker?name=myworker!./worker.js';
// or
require('worker?name=myworker!./worker.js');
```

``` js
// webpack.config.js
...
worker: {
    output: {
        filename: "[name].js"
    }
}
...
```

Should output `myworker.js`, but outputs `main.js` instead


Fixes #36