### PR TITLE
Use query.name as the name of the entry

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ module.exports.pitch = function(request) {
 	}
 	var workerCompiler = this._compilation.createChildCompiler("worker", outputOptions);
 	workerCompiler.apply(new WebWorkerTemplatePlugin(outputOptions));
-	workerCompiler.apply(new SingleEntryPlugin(this.context, "!!" + request, "main"));
+	workerCompiler.apply(new SingleEntryPlugin(this.context, "!!" + request, query.name || "main"));
 	if(this.options && this.options.worker && this.options.worker.plugins) {
 		this.options.worker.plugins.forEach(function(plugin) {
 			workerCompiler.apply(plugin);


### PR DESCRIPTION
This is useful if different output builds are used. E.g. an es5 and es6 build.
Without this option, one build overrides the results of the other one.
Having the option to pass the name, combined with a configured output options
for the worker loader, different output files can be targeted (without
to have using hashes).
