### PR TITLE
Add global option if web worker should be inlined

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,8 @@ module.exports.pitch = function(request) {
 			outputOptions[name] = this.options.worker.output[name];
 		}
 	}
+
+    var inline = !!(typeof query !== "undefined" ? query.inline : this.options && this.options.worker && this.options.worker.inline);
 	var workerCompiler = this._compilation.createChildCompiler("worker", outputOptions);
 	workerCompiler.apply(new WebWorkerTemplatePlugin(outputOptions));
 	workerCompiler.apply(new SingleEntryPlugin(this.context, "!!" + request, "main"));
@@ -44,7 +46,8 @@ module.exports.pitch = function(request) {
 		if (entries[0]) {
 			var workerFile = entries[0].files[0];
 			var constructor = "new Worker(__webpack_public_path__ + " + JSON.stringify(workerFile) + ")";
-			if(query.inline) {
+
+			if(inline) {
 				constructor = "require(" + JSON.stringify("!!" + path.join(__dirname, "createInlineWorker.js")) + ")(" +
 					JSON.stringify(compilation.assets[workerFile].source()) + ", __webpack_public_path__ + " + JSON.stringify(workerFile) + ")";
 			}


### PR DESCRIPTION
Add a global option that allows to define if the web worker code
should be inlined or not. The query.inline option has higher priority
then the global one. Allows to create multiple builds, one with inlined
web worker and one where the code is not inlined
