### PR TITLE
Allow worker-loader to run with webpack@2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Tobias Koppers @sokra",
   "description": "worker loader module for webpack",
   "peerDependencies": {
-    "webpack": ">=0.9 <2 || ^2.1.0-beta"
+    "webpack": ">=0.9 <2 || ^2.1.0-beta || ^2.2.0"
   },
   "dependencies": {
     "loader-utils": "0.2.x"


### PR DESCRIPTION
Currently, there's a peerdep warning when using worker-loader with webpack@2.2.0.

> "worker-loader@0.7.1" has incorrect peer dependency "webpack@>=0.9 <2 || ^2.1.0-beta"

As far as I can tell, it works just fine with the final release of webpack2. Are there any bugs I should fix first?