### PR TITLE
docs(README): move usage link to header

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,7 @@ or
 yarn add worker-loader --dev
 ```
 
-<h2 align="center">Usage</h2>
-
-[Documentation: Using loaders](https://webpack.js.org/concepts/loaders/)
+<h2 align="center"><a href="https://webpack.js.org/concepts/loaders">Usage</a></h2>
 
 Import the worker file:
 


### PR DESCRIPTION
For consistency with other loaders, see https://github.com/webpack-contrib/bundle-loader/pull/47