### PR TITLE
feat: support loading node core modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ module.exports.pitch = function pitch(request) {
   }
   const workerCompiler = this._compilation.createChildCompiler('worker', outputOptions);
   workerCompiler.apply(new WebWorkerTemplatePlugin(outputOptions));
-  if (this.options.target !== 'webworker' && this.options.target !== 'web') {
+  if (this.target !== 'webworker' && this.target !== 'web') {
     workerCompiler.apply(new NodeTargetPlugin());
   }
   workerCompiler.apply(new SingleEntryPlugin(this.context, `!!${request}`, 'main'));

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 const path = require('path');
 const WebWorkerTemplatePlugin = require('webpack/lib/webworker/WebWorkerTemplatePlugin');
-const NodeTargetPlugin = require("webpack/lib/node/NodeTargetPlugin");
+const NodeTargetPlugin = require('webpack/lib/node/NodeTargetPlugin');
 const SingleEntryPlugin = require('webpack/lib/SingleEntryPlugin');
 const loaderUtils = require('loader-utils');
 
@@ -39,11 +39,9 @@ module.exports.pitch = function pitch(request) {
   }
   const workerCompiler = this._compilation.createChildCompiler('worker', outputOptions);
   workerCompiler.apply(new WebWorkerTemplatePlugin(outputOptions));
-  
   if (this.options.target !== 'webworker' && this.options.target !== 'web'){
     workerCompiler.apply(new NodeTargetPlugin());
   }
-  
   workerCompiler.apply(new SingleEntryPlugin(this.context, `!!${request}`, 'main'));
   if (this.options && this.options.worker && this.options.worker.plugins) {
     this.options.worker.plugins.forEach(plugin => workerCompiler.apply(plugin));

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 const path = require('path');
 const WebWorkerTemplatePlugin = require('webpack/lib/webworker/WebWorkerTemplatePlugin');
+const NodeTargetPlugin = require("webpack/lib/node/NodeTargetPlugin");
 const SingleEntryPlugin = require('webpack/lib/SingleEntryPlugin');
 const loaderUtils = require('loader-utils');
 
@@ -38,6 +39,11 @@ module.exports.pitch = function pitch(request) {
   }
   const workerCompiler = this._compilation.createChildCompiler('worker', outputOptions);
   workerCompiler.apply(new WebWorkerTemplatePlugin(outputOptions));
+  
+  if (this.options.target !== 'webworker' && this.options.target !== 'web'){
+    workerCompiler.apply(new NodeTargetPlugin());
+  }
+  
   workerCompiler.apply(new SingleEntryPlugin(this.context, `!!${request}`, 'main'));
   if (this.options && this.options.worker && this.options.worker.plugins) {
     this.options.worker.plugins.forEach(plugin => workerCompiler.apply(plugin));

--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ module.exports.pitch = function pitch(request) {
   }
   const workerCompiler = this._compilation.createChildCompiler('worker', outputOptions);
   workerCompiler.apply(new WebWorkerTemplatePlugin(outputOptions));
-  if (this.options.target !== 'webworker' && this.options.target !== 'web'){
+  if (this.options.target !== 'webworker' && this.options.target !== 'web') {
     workerCompiler.apply(new NodeTargetPlugin());
   }
   workerCompiler.apply(new SingleEntryPlugin(this.context, `!!${request}`, 'main'));

--- a/test/fixtures/nodejs-core-modules/entry.js
+++ b/test/fixtures/nodejs-core-modules/entry.js
@@ -1,0 +1,1 @@
+const Worker = require('../../../index.js!./worker.js');

--- a/test/fixtures/nodejs-core-modules/worker.js
+++ b/test/fixtures/nodejs-core-modules/worker.js
@@ -1,0 +1,1 @@
+const fs = require('fs');

--- a/test/index.js
+++ b/test/index.js
@@ -184,7 +184,7 @@ describe('worker-loader', () => {
   ['web', 'webworker'].forEach((target) => {
     it(`should have missing dependencies (${target})`, () =>
       makeBundle('nodejs-core-modules', {
-        target: target,
+        target,
         module: {
           rules: [
             {
@@ -206,7 +206,7 @@ describe('worker-loader', () => {
   ['node', 'async-node', 'node-webkit', 'atom', 'electron', 'electron-main', 'electron-renderer'].forEach((target) => {
     it(`should not have missing dependencies (${target})`, () =>
       makeBundle('nodejs-core-modules', {
-        target: target,
+        target,
         module: {
           rules: [
             {

--- a/test/index.js
+++ b/test/index.js
@@ -181,42 +181,47 @@ describe('worker-loader', () => {
     })
   );
 
-  it('should have missing dependencies', () =>
-    makeBundle('nodejs-core-modules', {
-      module: {
-        rules: [
-          {
-            test: /worker\.js$/,
-            loader: '../index.js',
-            options: {
-              inline: true,
-              fallback: false,
+  ['web', 'webworker'].forEach((target) => {
+    it(`should have missing dependencies (${target})`, () =>
+      makeBundle('nodejs-core-modules', {
+        target: target,
+        module: {
+          rules: [
+            {
+              test: /worker\.js$/,
+              loader: '../index.js',
+              options: {
+                inline: true,
+                fallback: false,
+              },
             },
-          },
-        ],
-      },
-    }).then((stats) => {
-      assert.notEqual(stats.compilation.missingDependencies.length, 0);
-    })
-  );
+          ],
+        },
+      }).then((stats) => {
+        assert.notEqual(stats.compilation.missingDependencies.length, 0);
+      })
+    );
+  });
 
-  it('should not have missing dependencies', () =>
-    makeBundle('nodejs-core-modules', {
-      target: 'node-webkit',
-      module: {
-        rules: [
-          {
-            test: /worker\.js$/,
-            loader: '../index.js',
-            options: {
-              inline: true,
-              fallback: false,
+  ['node', 'async-node', 'node-webkit', 'atom', 'electron', 'electron-main', 'electron-renderer'].forEach((target) => {
+    it(`should not have missing dependencies (${target})`, () =>
+      makeBundle('nodejs-core-modules', {
+        target: target,
+        module: {
+          rules: [
+            {
+              test: /worker\.js$/,
+              loader: '../index.js',
+              options: {
+                inline: true,
+                fallback: false,
+              },
             },
-          },
-        ],
-      },
-    }).then((stats) => {
-      assert.equal(stats.compilation.missingDependencies.length, 0);
-    })
-  );
+          ],
+        },
+      }).then((stats) => {
+        assert.equal(stats.compilation.missingDependencies.length, 0);
+      })
+    );
+  });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -180,4 +180,43 @@ describe('worker-loader', () => {
       assert.notEqual(readFile(bundleFile).indexOf('// w2 inlined without fallback'), -1);
     })
   );
+
+  it('should have missing dependencies', () =>
+    makeBundle('nodejs-core-modules', {
+      module: {
+        rules: [
+          {
+            test: /worker\.js$/,
+            loader: '../index.js',
+            options: {
+              inline: true,
+              fallback: false,
+            },
+          },
+        ],
+      },
+    }).then((stats) => {
+      assert.notEqual(stats.compilation.missingDependencies.length, 0);
+    })
+  );
+
+  it('should not have missing dependencies', () =>
+    makeBundle('nodejs-core-modules', {
+      target: 'node-webkit',
+      module: {
+        rules: [
+          {
+            test: /worker\.js$/,
+            loader: '../index.js',
+            options: {
+              inline: true,
+              fallback: false,
+            },
+          },
+        ],
+      },
+    }).then((stats) => {
+      assert.equal(stats.compilation.missingDependencies.length, 0);
+    })
+  );
 });


### PR DESCRIPTION
Should no longer throw errors for missing node modules, such as `fs`, `path` and etc.

It applies `NodeTargetPlugin` to child compiler if the main target uses `NodeTargetPlugin`. Every target apart from `webworker` and `web` use `NodeTargetPlugin`.

Fixes #44, #55