### PR TITLE
Add webpack 3.0 to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     }
   },
   "peerDependencies": {
-    "webpack": ">=0.9 <2 || ^2.1.0-beta || ^2.2.0"
+    "webpack": ">=0.9 <2 || ^2.1.0-beta || ^2.2.0 || ^3.0.0"
   },
   "dependencies": {
     "loader-utils": "^1.0.2",


### PR DESCRIPTION
Adds webpack 3.0 to peerDependencies so we no longer see warnings about incorrect deps.
```
warning "worker-loader@0.8.1" has incorrect peer dependency "webpack@>=0.9 <2 || ^2.1.0-beta || ^2.2.0".
```