### PR TITLE
refactor(index): remove `Tapable.apply` calls

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -52,13 +52,13 @@ export function pitch(request) {
   worker.compiler = this._compilation
     .createChildCompiler('worker', worker.options);
 
-  worker.compiler.apply(new WebWorkerTemplatePlugin(worker.options));
+  new WebWorkerTemplatePlugin(worker.options).apply(worker.compiler);
 
   if (this.target !== 'webworker' && this.target !== 'web') {
-    worker.compiler.apply(new NodeTargetPlugin());
+    new NodeTargetPlugin().apply(worker.compiler);
   }
 
-  worker.compiler.apply(new SingleEntryPlugin(this.context, `!!${request}`, 'main'));
+  new SingleEntryPlugin(this.context, `!!${request}`, 'main').apply(worker.compiler);
 
   const subCache = `subcache ${__dirname} ${request}`;
 

--- a/src/index.js
+++ b/src/index.js
@@ -52,6 +52,8 @@ export function pitch(request) {
   worker.compiler = this._compilation
     .createChildCompiler('worker', worker.options);
 
+  // Tapable.apply is deprecated in tapable@1.0.0-x.
+  // The plugins should now call apply themselves.
   new WebWorkerTemplatePlugin(worker.options).apply(worker.compiler);
 
   if (this.target !== 'webworker' && this.target !== 'web') {


### PR DESCRIPTION
`Tapable.apply` is deprecated in `tapable@1.0.0-x`.
The plugins should now call `apply` themselves.

Fixes #136