### PR TITLE
fix(package): homepage URL typo

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   },
   "repository": "https://github.com/webpack-contrib/worker-loader.git",
   "bugs": "https://github.com/webpack-contrib/worker-loader/issues",
-  "homepage": "https://github.com/webpack-contrib/html-loader",
+  "homepage": "https://github.com/webpack-contrib/worker-loader",
   "license": "MIT",
   "pre-commit": "lint-staged",
   "lint-staged": {


### PR DESCRIPTION
Cosmetic change: fixed the URL field in `package.json` (wrong copy-paste probably)