### PR TITLE
docs(README): add note about omitted hashes (`options.name`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,13 @@ worker.addEventListener("message", function (event) {});
 
 |Name|Type|Default|Description|
 |:--:|:--:|:-----:|:----------|
-|[**`name`**](#name)|`{String}`|`[hash].worker.js`|Set a custom name for the output script|
+|[**`name`**](#name)|`{String}`|`[hash].worker.js`|Set a custom name for the output script| 
 |[**`inline`**](#inline)|`{Boolean}`|`false`|Inline the worker as a BLOB|
 |[**`fallback`**](#fallback)|`{Boolean}`|`false`|Require a fallback for non-worker supporting environments|
 |[**`publicPath`**](#publicPath)|`{String}`|`null`|Override the path from which worker scripts are downloaded|
 
+## NOTE:
+when using name alone hash is omitted
 ### `name`
 
 To set a custom name for the output script, use the `name` parameter. The name may contain the string `[hash]`, which will be replaced with a content dependent hash for caching purposes

--- a/README.md
+++ b/README.md
@@ -66,11 +66,9 @@ worker.addEventListener("message", function (event) {});
 |[**`fallback`**](#fallback)|`{Boolean}`|`false`|Require a fallback for non-worker supporting environments|
 |[**`publicPath`**](#publicPath)|`{String}`|`null`|Override the path from which worker scripts are downloaded|
 
-## NOTE:
-when using name alone hash is omitted
 ### `name`
 
-To set a custom name for the output script, use the `name` parameter. The name may contain the string `[hash]`, which will be replaced with a content dependent hash for caching purposes
+To set a custom name for the output script, use the `name` parameter. The name may contain the string `[hash]`, which will be replaced with a content dependent hash for caching purposes. When using name alone hash is omitted.
 
 *webpack.config.js**
 ```js

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ worker.addEventListener("message", function (event) {});
 
 ### `name`
 
-To set a custom name for the output script, use the `name` parameter. The name may contain the string `[hash]`, which will be replaced with a content dependent hash for caching purposes. When using name alone hash is omitted.
+To set a custom name for the output script, use the `name` parameter. The name may contain the string `[hash]`, which will be replaced with a content dependent hash for caching purposes. When using `name` alone `[hash]` is omitted.
 
 *webpack.config.js**
 ```js


### PR DESCRIPTION
README.md updated with instruction to remove hash from file name if needed.