### PR TITLE
Use ES6 import in TypeScript README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ declare module "worker-loader!*" {
     constructor();
   }
 
-  export = WebpackWorker;
+  export default WebpackWorker;
 }
 ```
 
@@ -191,7 +191,7 @@ ctx.addEventListener("message", (event) => console.log(event));
 
 **App.ts**
 ```typescript
-import Worker = require("worker-loader!./Worker");
+import Worker from "worker-loader!./Worker";
 
 const worker = new Worker();
 


### PR DESCRIPTION
Updates the TypeScript example to use the ES6 import syntax like the other examples. Includes the change to `Worker.ts` mentioned in https://github.com/webpack-contrib/worker-loader/issues/111 to get it to work with `import` instead of `require`.

<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->
