### PR TITLE
Revert "Use ES6 import in TypeScript README example"

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ declare module "worker-loader!*" {
     constructor();
   }
 
-  export default WebpackWorker;
+  export = WebpackWorker;
 }
 ```
 
@@ -191,7 +191,7 @@ ctx.addEventListener("message", (event) => console.log(event));
 
 **App.ts**
 ```typescript
-import Worker from "worker-loader!./Worker";
+import Worker = require("worker-loader!./Worker");
 
 const worker = new Worker();
 


### PR DESCRIPTION
Reverts webpack-contrib/worker-loader#140

This syntax causes TypeScript to output incorrect code. worker-loader creates a module like the following:

```js
module.exports = function() {
  return /* factory */
};
```

To describe this module in TypeScript you would use

```ts
declare module moduleName {
  export = /* typeof factory */
}
```

and to import it you use

```ts
import moduleName = require('path/to/module');
```

This is how I originally wrote the docs. The change assumes that worker-loader uses a module of the form

```js
exports.default = function() {
  return /* factory */
};
```

and emitted code will attempt to reference the `default` property of the module, resulting in a `TypeError` whenever you try to use the module (since the property is undefined).

TypeScript doc reference: https://www.typescriptlang.org/docs/handbook/modules.html#export--and-import--require



