### PR TITLE
Add an Option to Specify Module System of Output

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -106,9 +106,13 @@ export function pitch(request) {
         delete this._compilation.assets[worker.file];
       }
 
+      const moduleCode = `function() {\n  return ${worker.factory};\n}`;
+
       return cb(
         null,
-        `module.exports = function() {\n  return ${worker.factory};\n};`
+        options.outputModule === 'es6'
+          ? `export default ${moduleCode}`
+          : `module.exports = ${moduleCode};`
       );
     }
 

--- a/src/options.json
+++ b/src/options.json
@@ -12,6 +12,10 @@
     },
     "publicPath": {
       "type": "string"
+    },
+    "outputModule": {
+      "type": "string",
+      "enum": ["es6", "commonjs"]
     }
   },
   "additionalProperties": false


### PR DESCRIPTION
+ New option `outputModule` is added with enum: 'es6' and 'commonjs'.
+ This is a pre-requisition for treeshaking.

<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [X] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

I'm using Typescript + Webpack 4 for a project. One of my setup's basic goals is to enable tree-shaking to reduce the final bundles' sizes. To make this possible, my Typescript's compiler config uses es6 module system which privents using of `import XXX_Module = require('module/file/path')` syntax. So I have to tell this loader to optionally emit es6-compatiable module.

Once this feature merged, for those Typescript projects, they can easily start to use this loader with one of below type definitions:

For es6 module system,
```typescript
declare module "worker-loader!*" {
  class WebpackWorker extends Worker {
    constructor();
  }

  export default WebpackWorker;
}
```
For cjs module system,
```typescript
declare module "worker-loader!*" {
  class WebpackWorker extends Worker {
    constructor();
  }

  export = WebpackWorker;
}
```

Also, emitting commonjs modules by this loader makes tree-shaking impossible since it only works with es6 module system. Though, this PR won't enable tree-shaking immediately, emitting a es6 module could be a fundation of enabling tree-shaking with another code change.

### Breaking Changes

This PR shouldn't break the current loader and any projects using this loader, since by default, it still emits commonjs module.

### Additional Info