### PR TITLE
Add ?url option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -95,6 +95,10 @@ export function pitch(request) {
 
     if (entries[0]) {
       worker.file = entries[0].files[0];
+      
+      if (options.url===true) {
+        return cb(null, `module.exports = __webpack_public_path__ + ${JSON.stringify(worker.file)}`);
+      }
 
       worker.factory = getWorker(
         worker.file,

--- a/src/index.js
+++ b/src/index.js
@@ -96,7 +96,7 @@ export function pitch(request) {
     if (entries[0]) {
       worker.file = entries[0].files[0];
       
-      if (options.url===true) {
+      if (options.url === true) {
         return cb(null, `module.exports = __webpack_public_path__ + ${JSON.stringify(worker.file)}`);
       }
 

--- a/src/options.json
+++ b/src/options.json
@@ -12,6 +12,9 @@
     },
     "publicPath": {
       "type": "string"
+    },
+    "url": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false


### PR DESCRIPTION
This new boolean option makes it possible to require() a worker and get back its compiled URL.
This is immensely useful when additional options are needed to be passed to the constructor.

This PR contains a:

- [x] new **feature**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->

### Motivation / Use-Case

This supports various cases where one needs to compile worker code via require(), but where the instantiation of the Worker needs to remain separate. Rather than worker-loader creating a Worker factory module, it simply outputs a module where the default export is the compiled worker's URL (asset url).

### Breaking Changes

None - it's under a new option/flag.

To try this out locally: `npm i developit/worker-loader#2.0.0-url`