### PR TITLE
docs(readme): update inline loading of worker script

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $ npm install worker-loader --save-dev
 
 ```js
 // App.js
-import Worker from 'worker-loader!./Worker.js';
+import Worker from 'worker-loader?inline=true!./Worker.js';
 ```
 
 ### Config


### PR DESCRIPTION
If you follow current readme to inline import the worker you get this below error
```
Uncaught SecurityError: Failed to construct 'Worker': Script at <domain of
webapp>  cannot be accessed from origin <domain the script is hosted>
```
Some github issues people have raised already for it
https://github.com/webpack-contrib/worker-loader/issues/8
https://github.com/webpack-contrib/worker-loader/issues/158
https://github.com/webpack-contrib/worker-loader/issues/154

<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->
Correcting the readme about loading the web worker inline
### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info