### PR TITLE
Apply FetchCompileWasmTemplatePlugin when webpack >= v4

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -66,6 +66,24 @@ export function pitch(request) {
     new NodeTargetPlugin().apply(worker.compiler);
   }
 
+  // webpack >= v4 supports webassembly
+  let wasmPluginPath = null;
+  try {
+    wasmPluginPath = require.resolve(
+      'webpack/lib/web/FetchCompileWasmTemplatePlugin'
+    );
+  } catch (_err) {
+    // webpack <= v3, skipping
+  }
+
+  if (wasmPluginPath) {
+    // eslint-disable-next-line global-require, import/no-dynamic-require
+    const FetchCompileWasmTemplatePlugin = require(wasmPluginPath);
+    new FetchCompileWasmTemplatePlugin({
+      mangleImports: this._compiler.options.optimization.mangleWasmImports,
+    }).apply(worker.compiler);
+  }
+
   new SingleEntryPlugin(this.context, `!!${request}`, 'main').apply(
     worker.compiler
   );


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

webpack >= v4 enables to bundle wasm file thanks to `FetchCompileWasmTemplatePlugin`.
See https://github.com/webpack/webpack/blob/v4.28.2/lib/WebpackOptionsApply.js#L110-L122

However, this loader doesn't apply `FetchCompileWasmTemplatePlugin`, so wasm cannot use in WebWorker via worker-loader.
Ref. webpack/webpack#7647

Sample code that caused issue is [here](https://gist.github.com/3846masa/55e7bea1699b34dabeeb9a6649d4bc78).

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info

`'webpack/lib/web/FetchCompileWasmTemplatePlugin'` doesn't exist in webpack <= v3.
This code checks that file via `require.resolve` for compatibility.