### PR TITLE
feat(options): new option `globalObject`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -51,6 +51,7 @@ export function pitch(request) {
     filename,
     chunkFilename: `[id].${filename}`,
     namedChunkFilename: null,
+    globalObject: options.globalObject || 'self',
   };
 
   worker.compiler = this._compilation.createChildCompiler(

--- a/src/options.json
+++ b/src/options.json
@@ -12,6 +12,9 @@
     },
     "publicPath": {
       "type": "string"
+    },
+    "globalObject": {
+      "type": "string"
     }
   },
   "additionalProperties": false


### PR DESCRIPTION
Allow configuration of globalObject for the worker's compiler, default to "self".

----

This PR contains a:

- [x] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [ ] **test update**
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Fixes #166 #170 webpack/webpack#6642 issues with HMR


### Breaking Changes

If an application was using worker-loader and explicitly setting `globalObject` different than `"self"`, it should now use the worker-loader's option `globalObject`. (I'm not expecting this to happen)

### Additional Info