### PR TITLE
Don't generate sourcemap for inline generation with fallback=false

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -104,6 +104,7 @@ export function pitch(request) {
 
       if (options.fallback === false) {
         delete this._compilation.assets[worker.file];
+        delete this._compilation.assets[worker.file + '.map'];
       }
 
       return cb(


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

I'm using typescript, and with inline=true and fallback=false. I get a sourcemap being incorrectly generated for a js file that isn't created.

### Breaking Changes

None that I'm aware of.

### Additional Info

n/a