### PR TITLE
fix: memory leak during inline webworker creation #208

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,6 +2,10 @@ module.exports = {
   root: true,
   plugins: ['prettier'],
   extends: ['@webpack-contrib/eslint-config-webpack'],
+  env: {
+    'browser': true,
+    'node': true
+  },
   rules: {
     'prettier/prettier': [
       'error',

--- a/package.json
+++ b/package.json
@@ -76,7 +76,15 @@
     "webpack"
   ],
   "jest": {
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "globals": {
+      "window": {}
+    }
+  },
+  "eslintConfig": {
+    "globals": {
+      "window": true
+    }
   },
   "pre-commit": "lint-staged",
   "lint-staged": {

--- a/src/workers/InlineWorker.js
+++ b/src/workers/InlineWorker.js
@@ -24,7 +24,11 @@ module.exports = function (content, url) {
         blob = new Blob([content]);
       }
 
-      return new Worker(URL.createObjectURL(blob));
+      var objectURL = URL.createObjectURL(blob);
+      var worker = new Worker(objectURL);
+      URL.revokeObjectURL(objectURL);
+
+      return worker;
     } catch (e) {
       return new Worker('data:application/javascript,' + encodeURIComponent(content));
     }

--- a/src/workers/InlineWorker.js
+++ b/src/workers/InlineWorker.js
@@ -1,7 +1,5 @@
 // http://stackoverflow.com/questions/10343913/how-to-create-a-web-worker-from-a-string
 
-var URL = window.URL || window.webkitURL;
-
 module.exports = function (content, url) {
   try {
     try {
@@ -21,22 +19,23 @@ module.exports = function (content, url) {
         blob = blob.getBlob();
       } catch (e) {
         // The proposed API
-        blob = new Blob([content]);
+        blob = new window.Blob([content]);
       }
 
+      var URL = window.URL || window.webkitURL;
       var objectURL = URL.createObjectURL(blob);
-      var worker = new Worker(objectURL);
+      var worker = new window.Worker(objectURL);
       URL.revokeObjectURL(objectURL);
 
       return worker;
     } catch (e) {
-      return new Worker('data:application/javascript,' + encodeURIComponent(content));
+      return new window.Worker('data:application/javascript,' + encodeURIComponent(content));
     }
   } catch (e) {
     if (!url) {
       throw Error('Inline worker is not supported');
     }
 
-    return new Worker(url);
+    return new window.Worker(url);
   }
 };

--- a/test/InlineWorker.test.js
+++ b/test/InlineWorker.test.js
@@ -1,0 +1,24 @@
+import InlineWorker from './../src/workers/InlineWorker';
+
+describe('Inline Worker', () => {
+  const objectUrlCreatedDuringWorkerCreation = () => {
+    const createdObjectUrl = 'OBJECT_URL';
+    window.URL = {
+      createObjectURL: jest.fn().mockReturnValue(createdObjectUrl),
+      revokeObjectURL: jest.fn(),
+    };
+    window.Worker = jest.fn();
+    window.Blob = jest.fn();
+    window.BlobBuilder = jest.fn();
+
+    return createdObjectUrl;
+  };
+
+  test('calls revokeObjectURL after creating worker to prevent memory leaks', () => {
+    const createdObjectUrl = objectUrlCreatedDuringWorkerCreation();
+
+    InlineWorker('some_content', 'some_url');
+
+    expect(window.URL.revokeObjectURL).toHaveBeenCalledWith(createdObjectUrl);
+  });
+});


### PR DESCRIPTION

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x] **test update** 
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

solving memory issue described in #208 

### Breaking Changes

none

### Additional Info

* updated lint config to allow usage of global window object in tests
* updated jest config to mock global window object