### PR TITLE
feat(options): add options.runtimeImportFunctionName

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,28 @@ the same public path used for other webpack assets is used.
 }
 ```
 
+### runtimeImportFunctionName
+
+Type: `String`
+Default: `null`
+
+Specifies a function, by name, to be called at runtime, just before the worker is created.
+The function must receive a single string argument and must return a string.
+
+```js
+// webpack.config.js
+{
+  loader: 'worker-loader',
+  options: { runtimeImportFunctionName: 'getWorkerPath' }
+}
+
+// App.js
+function getWorkerPath(workerPath) {
+  return '/scripts/workers/' + workerPath;
+}
+const Worker = require('./Worker.js');
+```
+
 ## Examples
 
 The worker file can import dependencies just like any other file:

--- a/src/options.json
+++ b/src/options.json
@@ -11,7 +11,10 @@
       "type": "boolean"
     },
     "publicPath": {
-      "type": "string"
+      "type": "string" 
+    },
+    "runtimeImportFunctionName": {
+      "type": "string" 
     }
   },
   "additionalProperties": false

--- a/src/workers/index.js
+++ b/src/workers/index.js
@@ -21,6 +21,11 @@ const getWorker = (file, content, options) => {
     )}, ${fallbackWorkerPath})`;
   }
 
+  if (options.runtimeImportFunctionName) {
+    const fn = options.runtimeImportFunctionName;
+    return `new Worker(${fn}(${publicWorkerPath}))`;
+  }
+
   return `new Worker(${publicWorkerPath})`;
 };
 

--- a/test/fixtures/runtime-import-function-name/entry.js
+++ b/test/fixtures/runtime-import-function-name/entry.js
@@ -1,0 +1,5 @@
+function testRuntimeFunction(publicWorkerPath) {
+	return '/some/other/proxy/' + publicWorkerPath;
+}
+
+const Worker = require('./worker.js');

--- a/test/fixtures/runtime-import-function-name/worker.js
+++ b/test/fixtures/runtime-import-function-name/worker.js
@@ -1,0 +1,1 @@
+// named worker test mark

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -192,6 +192,25 @@ test('should use the publicPath option as the base URL if specified', () =>
     );
   }));
 
+test('should invoke a function named after the value of runtimeImportFunctionName when creating the Worker', () => {
+  webpack('runtime-import-function-name', {
+    loader: {
+      options: {
+        runtimeImportFunctionName: 'testRuntimeFunction',
+      },
+    },
+  }).then((stats) => {
+    const assets = stats.compilation.assets;
+
+    const bundle = assets['bundle.js'];
+    const worker = Object.keys(assets)[1];
+
+    expect(bundle.source()).toContain(
+      `new Worker(testRuntimeFunction(__webpack_require__.p + "${worker}"))`
+    );
+  });
+});
+
 ['web', 'webworker'].forEach((target) => {
   test(`should have missing dependencies (${target})`, () =>
     webpack('nodejs-core-modules', {


### PR DESCRIPTION
### Description
This feature allows a browser to determine, at runtime, the relative path from where to import the worker script file.

I decided to avoid using `publicPath` because I concluded that it's best to have it resolved during build time by webpack.
Instead, `options.runtimeImportFunctionName` is meant to be used during runtime. It can be combined with `options.publicPath`, too.

<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->
In browser context, the script that pulls imports the worker script file (not inlined) may be served from different URL paths, thus `option.publicPath` is unable to provide the relative path from where to download the worker script.

Example: 
- Build outputs files `dist/index.js` and `dist/worker.js`
- **Case 1**: Files get deployed into https://my.website.com/cdn/index.js and https://my.website.com/cdn/worker.js, respectively. 
  - `index.js` needs to import `worker.js` from `/cdn/`
- **Case 2**: Files get deployed into https://another.website.com/something/index.js and https://another.website.com/something/worker.js, respectively.
  - `index.js` needs to import `worker.js` from `/something/`

The path value cannot be specified during build time, so another approach is needed (this PR).
I need a function that executes during runtime, providing the appropriate path.

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->
- There are no breaking changes

### Additional Info
- It somewhat addresses issue #161 
- Updated README.md