### PR TITLE
feat: return the url of the worker file

### DIFF
--- a/src/workers/index.js
+++ b/src/workers/index.js
@@ -1,12 +1,16 @@
 /* eslint-disable multiline-ternary */
 import path from 'path';
 
-const getWorker = (file, content, options) => {
+const getWorkerPath = (file, options) => {
   const publicPath = options.publicPath
     ? JSON.stringify(options.publicPath)
     : '__webpack_public_path__';
 
-  const publicWorkerPath = `${publicPath} + ${JSON.stringify(file)}`;
+  return `${publicPath} + ${JSON.stringify(file)}`;
+};
+
+const getWorker = (file, content, options) => {
+  const publicWorkerPath = getWorkerPath(file, options);
 
   if (options.inline) {
     const InlineWorkerPath = JSON.stringify(
@@ -24,4 +28,10 @@ const getWorker = (file, content, options) => {
   return `new Worker(${publicWorkerPath})`;
 };
 
-export default getWorker;
+const getWorkerFactory = (file, content, options) => {
+  const worker = getWorker(file, content, options);
+  const workerPath = getWorkerPath(file, options);
+  return `module.exports = function () {\n  return ${worker};\n};\nmodule.exports.url = '${workerPath}';`;
+};
+
+export default getWorkerFactory;

--- a/test/fixtures/inline-query/entry.js
+++ b/test/fixtures/inline-query/entry.js
@@ -1,1 +1,1 @@
-const Worker = require('!../../../src?inline!./worker.js');
+const Worker = require('!../../../src?inline&name=[hash].worker.js!./worker.js');

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -93,6 +93,7 @@ test('should inline worker with inline in options', () =>
       test: /(w1|w2)\.js$/,
       options: {
         inline: true,
+        name: '[hash].worker.js',
       },
     },
   }).then((stats) => {
@@ -178,6 +179,7 @@ test('should use the publicPath option as the base URL if specified', () =>
   webpack('public-path-override', {
     loader: {
       options: {
+        name: '[hash].worker.js',
         publicPath: '/some/proxy/',
       },
     },


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [x] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

fix #226 and #11. With this change, developers can decide which Worker they want to use. Currently, Worker is allowed. What about [ServiceWorker](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorker) or [SharedWorker](https://developer.mozilla.org/en-US/docs/Web/API/SharedWorker)

I want to have a discussion first before writing tests for url
