### PR TITLE
Add WorkerType functionality (replaces #178)

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,12 +176,12 @@ module.exports = {
 };
 ```
 
-### sharedWorker
+### workerType
 
-Type: `boolean`
-Default: `false`
+Type: `string`
+Default: `Worker`
 
-Uses SharedWorker rather than Worker.
+Set the worker type. Defaults to `Worker`. Supports `ServiceWorker`, `SharedWorker`.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,13 @@ module.exports = {
 };
 ```
 
+### sharedWorker
+
+Type: `boolean`
+Default: `false`
+
+Uses SharedWorker rather than Worker.
+
 ## Examples
 
 ### Basic

--- a/src/options.json
+++ b/src/options.json
@@ -12,6 +12,9 @@
     },
     "publicPath": {
       "type": "string"
+    },
+    "sharedWorker": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false

--- a/src/options.json
+++ b/src/options.json
@@ -13,8 +13,8 @@
     "publicPath": {
       "type": "string"
     },
-    "sharedWorker": {
-      "type": "boolean"
+    "workerType": {
+      "type": "string"
     }
   },
   "additionalProperties": false

--- a/src/workers/InlineWorker.js
+++ b/src/workers/InlineWorker.js
@@ -5,14 +5,18 @@
 
 var URL = window.URL || window.webkitURL;
 
-function CreateWorker(url, shared) {
-  if (shared) {
-    return new SharedWorker(url);
+function CreateWorker(url, workerType) {
+  switch (workerType) {
+    case 'SharedWorker':
+      return new SharedWorker(url);
+    case 'ServiceWorker':
+      return new ServiceWorker(url);
+    default:
+      return new Worker(url);
   }
-  return new Worker(url);
 }
 
-module.exports = function inlineWorker(content, url, sharedWorker) {
+module.exports = function inlineWorker(content, url, workerType) {
   try {
     try {
       var blob;
@@ -35,11 +39,11 @@ module.exports = function inlineWorker(content, url, sharedWorker) {
         blob = new Blob([content]);
       }
 
-      return CreateWorker(URL.createObjectURL(blob), sharedWorker);
+      return CreateWorker(URL.createObjectURL(blob), workerType);
     } catch (e) {
       return CreateWorker(
         'data:application/javascript,' + encodeURIComponent(content),
-        sharedWorker
+        workerType
       );
     }
   } catch (e) {
@@ -47,6 +51,6 @@ module.exports = function inlineWorker(content, url, sharedWorker) {
       throw Error('Inline worker is not supported');
     }
 
-    return CreateWorker(url, sharedWorker);
+    return CreateWorker(url, workerType);
   }
 };

--- a/src/workers/InlineWorker.js
+++ b/src/workers/InlineWorker.js
@@ -5,7 +5,14 @@
 
 var URL = window.URL || window.webkitURL;
 
-module.exports = function inlineWorker(content, url) {
+function CreateWorker(url, shared) {
+  if (shared) {
+    return new SharedWorker(url);
+  }
+  return new Worker(url);
+}
+
+module.exports = function inlineWorker(content, url, sharedWorker) {
   try {
     try {
       var blob;
@@ -28,10 +35,10 @@ module.exports = function inlineWorker(content, url) {
         blob = new Blob([content]);
       }
 
-      return new Worker(URL.createObjectURL(blob));
+      return CreateWorker(URL.createObjectURL(blob), sharedWorker);
     } catch (e) {
-      return new Worker(
-        'data:application/javascript,' + encodeURIComponent(content)
+      return CreateWorker(
+        'data:application/javascript,' + encodeURIComponent(content), sharedWorker
       );
     }
   } catch (e) {
@@ -39,6 +46,6 @@ module.exports = function inlineWorker(content, url) {
       throw Error('Inline worker is not supported');
     }
 
-    return new Worker(url);
+    return CreateWorker(url, sharedWorker);
   }
 };

--- a/src/workers/InlineWorker.js
+++ b/src/workers/InlineWorker.js
@@ -38,7 +38,8 @@ module.exports = function inlineWorker(content, url, sharedWorker) {
       return CreateWorker(URL.createObjectURL(blob), sharedWorker);
     } catch (e) {
       return CreateWorker(
-        'data:application/javascript,' + encodeURIComponent(content), sharedWorker
+        'data:application/javascript,' + encodeURIComponent(content),
+        sharedWorker
       );
     }
   } catch (e) {

--- a/src/workers/index.js
+++ b/src/workers/index.js
@@ -19,7 +19,7 @@ const getWorker = (file, content, options) => {
       content
     )}, ${fallbackWorkerPath}, ${options.sharedWorker})`;
   }
-  const worker = options.sharedWorker ? `SharedWorker` : `Worker`
+  const worker = options.sharedWorker ? `SharedWorker` : `Worker`;
   return `new ${worker}(${publicWorkerPath})`;
 };
 

--- a/src/workers/index.js
+++ b/src/workers/index.js
@@ -17,10 +17,10 @@ const getWorker = (file, content, options) => {
 
     return `require(${InlineWorkerPath})(${JSON.stringify(
       content
-    )}, ${fallbackWorkerPath})`;
+    )}, ${fallbackWorkerPath}, ${options.sharedWorker})`;
   }
-
-  return `new Worker(${publicWorkerPath})`;
+  const worker = options.sharedWorker ? `SharedWorker` : `Worker`
+  return `new ${worker}(${publicWorkerPath})`;
 };
 
 export default getWorker;

--- a/src/workers/index.js
+++ b/src/workers/index.js
@@ -17,9 +17,21 @@ const getWorker = (file, content, options) => {
 
     return `require(${InlineWorkerPath})(${JSON.stringify(
       content
-    )}, ${fallbackWorkerPath}, ${options.sharedWorker})`;
+    )}, ${fallbackWorkerPath}, ${options.workerType})`;
   }
-  const worker = options.sharedWorker ? `SharedWorker` : `Worker`;
+
+  let worker = 'Worker';
+  switch (options.workerType) {
+    case 'SharedWorker':
+      worker = 'SharedWorker';
+      break;
+    case 'ServiceWorker':
+      worker = 'ServiceWorker';
+      break;
+    default:
+      worker = 'Worker';
+  }
+
   return `new ${worker}(${publicWorkerPath})`;
 };
 


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Allows worker-loader to create other worker types by adding an option `workerType` which defaults to `Worker` but could be used to create `ServiceWorker` or `SharedWorker`.

### Breaking Changes

None

### Additional Info

This is an updated version of #178

Signed-off-by: Andrew Thornton <art27@cantab.net>

