### PR TITLE
Add ability to pass options to the constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ ctx.addEventListener('message', (event) => console.log(event));
 ```typescript
 import Worker from 'worker-loader!./Worker';
 
-const worker = new Worker();
+const worker = new Worker(); // can pass constructor options here too
 
 worker.postMessage({ a: 1 });
 worker.onmessage = (event) => {};

--- a/src/supportWebpack4.js
+++ b/src/supportWebpack4.js
@@ -37,7 +37,7 @@ export default function runAsChild(worker, request, options, cb) {
 
       return cb(
         null,
-        `module.exports = function() {\n  return ${worker.factory};\n};`
+        `module.exports = function(options) {\n  return ${worker.factory};\n};`
       );
     }
 

--- a/src/supportWebpack5.js
+++ b/src/supportWebpack5.js
@@ -39,7 +39,7 @@ export default function runAsChild(worker, options, cb) {
             options
           );
 
-          const newContent = `module.exports = function() {\n  return ${worker.factory};\n};`;
+          const newContent = `module.exports = function(options) {\n  return ${worker.factory};\n};`;
 
           return worker.compiler.cache.store(
             cacheIdent,

--- a/src/workers/InlineWorker.js
+++ b/src/workers/InlineWorker.js
@@ -5,7 +5,7 @@
 
 var URL = window.URL || window.webkitURL;
 
-function CreateWorker(url, options, workerType) {
+function CreateWorker(workerType, url, options) {
   switch (workerType) {
     case 'SharedWorker':
       return new SharedWorker(url, options);
@@ -39,12 +39,17 @@ module.exports = function inlineWorker(content, url, options, workerType) {
         blob = new Blob([content]);
       }
 
-      return CreateWorker(URL.createObjectURL(blob), options, workerType);
-    } catch (e) {
       return CreateWorker(
-        'data:application/javascript,' + encodeURIComponent(content),
+        workerType,
+        URL.createObjectURL(blob),
         options,
         workerType
+      );
+    } catch (e) {
+      return CreateWorker(
+        workerType,
+        'data:application/javascript,' + encodeURIComponent(content),
+        options
       );
     }
   } catch (e) {

--- a/src/workers/InlineWorker.js
+++ b/src/workers/InlineWorker.js
@@ -5,18 +5,18 @@
 
 var URL = window.URL || window.webkitURL;
 
-function CreateWorker(url, workerType) {
+function CreateWorker(url, options, workerType) {
   switch (workerType) {
     case 'SharedWorker':
-      return new SharedWorker(url);
+      return new SharedWorker(url, options);
     case 'ServiceWorker':
-      return new ServiceWorker(url);
+      return new ServiceWorker(url, options);
     default:
-      return new Worker(url);
+      return new Worker(url, options);
   }
 }
 
-module.exports = function inlineWorker(content, url, workerType) {
+module.exports = function inlineWorker(content, url, options, workerType) {
   try {
     try {
       var blob;
@@ -39,10 +39,11 @@ module.exports = function inlineWorker(content, url, workerType) {
         blob = new Blob([content]);
       }
 
-      return CreateWorker(URL.createObjectURL(blob), workerType);
+      return CreateWorker(URL.createObjectURL(blob), options, workerType);
     } catch (e) {
       return CreateWorker(
         'data:application/javascript,' + encodeURIComponent(content),
+        options,
         workerType
       );
     }
@@ -51,6 +52,6 @@ module.exports = function inlineWorker(content, url, workerType) {
       throw Error('Inline worker is not supported');
     }
 
-    return CreateWorker(url, workerType);
+    return CreateWorker(url, options, workerType);
   }
 };

--- a/src/workers/index.js
+++ b/src/workers/index.js
@@ -17,7 +17,7 @@ const getWorker = (file, content, options) => {
 
     return `require(${InlineWorkerPath})(${JSON.stringify(
       content
-    )}, ${fallbackWorkerPath}, ${options.workerType})`;
+    )}, ${fallbackWorkerPath}, options, ${options.workerType})`;
   }
 
   let worker = 'Worker';
@@ -32,7 +32,7 @@ const getWorker = (file, content, options) => {
       worker = 'Worker';
   }
 
-  return `new ${worker}(${publicWorkerPath})`;
+  return `new ${worker}(${publicWorkerPath}, options)`;
 };
 
 export default getWorker;


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

When creating SharedWorkers with the new workerType option it would be helpful to set the name of the worker. This would also allow users to set the credentials options

### Additional Info

See: https://developer.mozilla.org/en-US/docs/Web/API/Worker/Worker
See: https://developer.mozilla.org/en-US/docs/Web/API/SharedWorker/SharedWorker

Signed-off-by: Andrew Thornton <art27@cantab.net>

