### PR TITLE
feat: switch on ES module syntax

### DIFF
--- a/src/options.json
+++ b/src/options.json
@@ -35,6 +35,9 @@
     },
     "publicPath": {
       "type": "string"
+    },
+    "esModule": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false

--- a/src/supportWebpack4.js
+++ b/src/supportWebpack4.js
@@ -37,9 +37,14 @@ export default function runAsChild(worker, request, options, callback) {
         delete this._compilation.assets[worker.file];
       }
 
+      const esModule =
+        typeof options.esModule !== 'undefined' ? options.esModule : true;
+
       return callback(
         null,
-        `module.exports = function() {\n  return ${worker.factory};\n};`
+        `${
+          esModule ? 'export default' : 'module.exports ='
+        } function() {\n  return ${worker.factory};\n};\n`
       );
     }
 

--- a/src/supportWebpack5.js
+++ b/src/supportWebpack5.js
@@ -39,7 +39,11 @@ export default function runAsChild(worker, options, callback) {
             options
           );
 
-          const newContent = `module.exports = function() {\n  return ${worker.factory};\n};`;
+          const esModule =
+            typeof options.esModule !== 'undefined' ? options.esModule : true;
+          const newContent = `${
+            esModule ? 'export default' : 'module.exports ='
+          } function() {\n  return ${worker.factory};\n};\n`;
 
           return worker.compiler.cache.store(
             cacheIdent,

--- a/test/__snapshots__/esModule-option.test.js.snap
+++ b/test/__snapshots__/esModule-option.test.js.snap
@@ -1,0 +1,38 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`"esModule" option should work and generate ES module syntax by default: errors 1`] = `Array []`;
+
+exports[`"esModule" option should work and generate ES module syntax by default: module 1`] = `
+"export default function() {
+  return new Worker(__webpack_public_path__ + \\"test.worker.js\\");
+};
+"
+`;
+
+exports[`"esModule" option should work and generate ES module syntax by default: warnings 1`] = `Array []`;
+
+exports[`"esModule" option should work with "false" value: errors 1`] = `Array []`;
+
+exports[`"esModule" option should work with "false" value: module 1`] = `
+"module.exports = function() {
+  return new Worker(__webpack_public_path__ + \\"test.worker.js\\");
+};
+"
+`;
+
+exports[`"esModule" option should work with "false" value: result 1`] = `"{\\"postMessage\\":true,\\"onmessage\\":true}"`;
+
+exports[`"esModule" option should work with "false" value: warnings 1`] = `Array []`;
+
+exports[`"esModule" option should work with "true" value: errors 1`] = `Array []`;
+
+exports[`"esModule" option should work with "true" value: module 1`] = `
+"export default function() {
+  return new Worker(__webpack_public_path__ + \\"test.worker.js\\");
+};
+"
+`;
+
+exports[`"esModule" option should work with "true" value: result 1`] = `"{\\"postMessage\\":true,\\"onmessage\\":true}"`;
+
+exports[`"esModule" option should work with "true" value: warnings 1`] = `Array []`;

--- a/test/__snapshots__/inline-option.test.js.snap
+++ b/test/__snapshots__/inline-option.test.js.snap
@@ -3,9 +3,10 @@
 exports[`"inline" option should not work by default: errors 1`] = `Array []`;
 
 exports[`"inline" option should not work by default: module 1`] = `
-"module.exports = function() {
+"export default function() {
   return new Worker(__webpack_public_path__ + \\"test.worker.js\\");
-};"
+};
+"
 `;
 
 exports[`"inline" option should not work by default: result 1`] = `"{\\"postMessage\\":true,\\"onmessage\\":true}"`;
@@ -15,9 +16,10 @@ exports[`"inline" option should not work by default: warnings 1`] = `Array []`;
 exports[`"inline" option should not work with "false" value: errors 1`] = `Array []`;
 
 exports[`"inline" option should not work with "false" value: module 1`] = `
-"module.exports = function() {
+"export default function() {
   return new Worker(__webpack_public_path__ + \\"test.worker.js\\");
-};"
+};
+"
 `;
 
 exports[`"inline" option should not work with "false" value: result 1`] = `"{\\"postMessage\\":true,\\"onmessage\\":true}"`;

--- a/test/__snapshots__/loader.test.js.snap
+++ b/test/__snapshots__/loader.test.js.snap
@@ -3,9 +3,10 @@
 exports[`worker-loader should work with inline syntax: errors 1`] = `Array []`;
 
 exports[`worker-loader should work with inline syntax: module 1`] = `
-"module.exports = function() {
+"export default function() {
   return new Worker(__webpack_public_path__ + \\"test.worker.js\\");
-};"
+};
+"
 `;
 
 exports[`worker-loader should work with inline syntax: result 1`] = `"{\\"postMessage\\":true,\\"onmessage\\":true}"`;
@@ -15,9 +16,10 @@ exports[`worker-loader should work with inline syntax: warnings 1`] = `Array []`
 exports[`worker-loader should work: errors 1`] = `Array []`;
 
 exports[`worker-loader should work: module 1`] = `
-"module.exports = function() {
+"export default function() {
   return new Worker(__webpack_public_path__ + \\"test.worker.js\\");
-};"
+};
+"
 `;
 
 exports[`worker-loader should work: result 1`] = `"{\\"postMessage\\":true,\\"onmessage\\":true}"`;

--- a/test/__snapshots__/name-options.test.js.snap
+++ b/test/__snapshots__/name-options.test.js.snap
@@ -3,9 +3,10 @@
 exports[`"name" option should work: errors 1`] = `Array []`;
 
 exports[`"name" option should work: module 1`] = `
-"module.exports = function() {
+"export default function() {
   return new Worker(__webpack_public_path__ + \\"my-custom-name.js\\");
-};"
+};
+"
 `;
 
 exports[`"name" option should work: result 1`] = `"{\\"postMessage\\":true,\\"onmessage\\":true}"`;

--- a/test/__snapshots__/publicPath.test.js.snap
+++ b/test/__snapshots__/publicPath.test.js.snap
@@ -3,9 +3,10 @@
 exports[`"publicPath" option should use "__webpack_public_path__" by default: errors 1`] = `Array []`;
 
 exports[`"publicPath" option should use "__webpack_public_path__" by default: module 1`] = `
-"module.exports = function() {
+"export default function() {
   return new Worker(__webpack_public_path__ + \\"test.worker.js\\");
-};"
+};
+"
 `;
 
 exports[`"publicPath" option should use "__webpack_public_path__" by default: result 1`] = `"{\\"postMessage\\":true,\\"onmessage\\":true}"`;

--- a/test/__snapshots__/worker-option.test.js.snap
+++ b/test/__snapshots__/worker-option.test.js.snap
@@ -9,9 +9,10 @@ exports[`"workerType" option should support the "Worker" object value for inline
 exports[`"workerType" option should support the "Worker" object value: errors 1`] = `Array []`;
 
 exports[`"workerType" option should support the "Worker" object value: module 1`] = `
-"module.exports = function() {
+"export default function() {
   return new Worker(__webpack_public_path__ + \\"test.worker.js\\", {\\"type\\":\\"classic\\",\\"name\\":\\"worker-name\\"});
-};"
+};
+"
 `;
 
 exports[`"workerType" option should support the "Worker" object value: result 1`] = `"{\\"postMessage\\":true,\\"onmessage\\":true}"`;
@@ -21,9 +22,10 @@ exports[`"workerType" option should support the "Worker" object value: warnings 
 exports[`"workerType" option should support the "Worker" string value: errors 1`] = `Array []`;
 
 exports[`"workerType" option should support the "Worker" string value: module 1`] = `
-"module.exports = function() {
+"export default function() {
   return new Worker(__webpack_public_path__ + \\"test.worker.js\\");
-};"
+};
+"
 `;
 
 exports[`"workerType" option should support the "Worker" string value: result 1`] = `"{\\"postMessage\\":true,\\"onmessage\\":true}"`;
@@ -33,9 +35,10 @@ exports[`"workerType" option should support the "Worker" string value: warnings 
 exports[`"workerType" option should use "Worker" by default: errors 1`] = `Array []`;
 
 exports[`"workerType" option should use "Worker" by default: module 1`] = `
-"module.exports = function() {
+"export default function() {
   return new Worker(__webpack_public_path__ + \\"test.worker.js\\");
-};"
+};
+"
 `;
 
 exports[`"workerType" option should use "Worker" by default: result 1`] = `"{\\"postMessage\\":true,\\"onmessage\\":true}"`;

--- a/test/esModule-option.test.js
+++ b/test/esModule-option.test.js
@@ -1,0 +1,53 @@
+import {
+  compile,
+  getCompiler,
+  getErrors,
+  getModuleSource,
+  getResultFromBrowser,
+  getWarnings,
+} from './helpers';
+
+describe('"esModule" option', () => {
+  it('should work and generate ES module syntax by default', async () => {
+    const compiler = getCompiler('./basic/entry.js');
+    const stats = await compile(compiler);
+    // const result = await getResultFromBrowser(stats);
+
+    expect(getModuleSource('./basic/worker.js', stats)).toMatchSnapshot(
+      'module'
+    );
+    // expect(result).toMatchSnapshot('result');
+    expect(getWarnings(stats)).toMatchSnapshot('warnings');
+    expect(getErrors(stats)).toMatchSnapshot('errors');
+  });
+
+  it('should work with "true" value', async () => {
+    const compiler = getCompiler('./basic/entry.js', {
+      esModule: true,
+    });
+    const stats = await compile(compiler);
+    const result = await getResultFromBrowser(stats);
+
+    expect(getModuleSource('./basic/worker.js', stats)).toMatchSnapshot(
+      'module'
+    );
+    expect(result).toMatchSnapshot('result');
+    expect(getWarnings(stats)).toMatchSnapshot('warnings');
+    expect(getErrors(stats)).toMatchSnapshot('errors');
+  });
+
+  it('should work with "false" value', async () => {
+    const compiler = getCompiler('./basic/entry.js', {
+      esModule: false,
+    });
+    const stats = await compile(compiler);
+    const result = await getResultFromBrowser(stats);
+
+    expect(getModuleSource('./basic/worker.js', stats)).toMatchSnapshot(
+      'module'
+    );
+    expect(result).toMatchSnapshot('result');
+    expect(getWarnings(stats)).toMatchSnapshot('warnings');
+    expect(getErrors(stats)).toMatchSnapshot('errors');
+  });
+});

--- a/test/fixtures/basic/entry.js
+++ b/test/fixtures/basic/entry.js
@@ -1,4 +1,4 @@
-const Worker = require('./worker.js');
+import Worker from './worker.js';
 
 const worker = new Worker();
 

--- a/test/fixtures/query/entry.js
+++ b/test/fixtures/query/entry.js
@@ -1,4 +1,4 @@
-const Worker = require('!../../../src?name=test.worker.js!./my-worker-name.js');
+import Worker from '!../../../src?name=test.worker.js!./my-worker-name.js';
 
 const worker = new Worker();
 


### PR DESCRIPTION
BREAKING CHANGE: switch on ES module syntax by default, use the `esModule` option if you need backward compatibility with Common JS modules

<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

fixes #153

### Breaking Changes

Yes, now we use ES module syntax by default

### Additional Info

No