### PR TITLE
docs(readme): add missing escape char in options table

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ And run `webpack` via your preferred method.
 |    **[`publicPath`](#publicpath)**    |     `{String\|Function}`     |  based on `output.publicPath`   | specifies the public URL address of the output files when referenced in a browser |
 |      **[`filename`](#filename)**      |     `{String\|Function}`     |   based on `output.filename`    | The filename of entry chunks for web workers                                      |
 | **[`chunkFilename`](#chunkfilename)** |          `{String}`          | based on `output.chunkFilename` | The filename of non-entry chunks for web workers                                  |
-|        **[`inline`](#inline)**        | `'no-fallback' | 'fallback'` |           `undefined`           | Allow to inline the worker as a `BLOB`                                            |
+|        **[`inline`](#inline)**        | `'no-fallback'\|'fallback'`  |           `undefined`           | Allow to inline the worker as a `BLOB`                                            |
 |      **[`esModule`](#esmodule)**      |         `{Boolean}`          |             `true`              | Use ES modules syntax                                                             |
 
 ### `worker`


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [x] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

This missing escape character broke the options table making it seem like `fallback` was the default value for the `inline` option.

### Breaking Changes

N/A

### Additional Info

None