### PR TITLE
fix: do not match too many characters when removing sourceMappingURL …

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -87,7 +87,7 @@ ${
 }
 
 // Matches only the last occurrence of sourceMappingURL
-const innerRegex = /\s*[#@]\s*sourceMappingURL\s*=\s*([^\s'"]*)\s*/;
+const innerRegex = /\s*[#@]\s*sourceMappingURL\s*=\s*((?:[^\s'"\\]|\\[^n])*(?:\\n)?)\s*/;
 
 /* eslint-disable prefer-template */
 const sourceMappingURLRegex = RegExp(

--- a/src/utils.js
+++ b/src/utils.js
@@ -87,7 +87,7 @@ ${
 }
 
 // Matches only the last occurrence of sourceMappingURL
-const innerRegex = /\s*[#@]\s*sourceMappingURL\s*=\s*((?:[^\s'"\\]|\\[^n])*(?:\\n)?)\s*/;
+const innerRegex = /\s*[#@]\s*sourceMappingURL\s*=\s*(.*?(?=[\s'"]|\\n|$)(?:\\n)?)\s*/;
 
 /* eslint-disable prefer-template */
 const sourceMappingURLRegex = RegExp(

--- a/test/__snapshots__/inline-option.test.js.snap
+++ b/test/__snapshots__/inline-option.test.js.snap
@@ -55,6 +55,12 @@ exports[`"inline" option should work with "no-fallback" value and "esModule" wit
 
 exports[`"inline" option should work with "no-fallback" value and "esModule" with "true" value: warnings 1`] = `Array []`;
 
+exports[`"inline" option should work with "no-fallback" value and the "devtool" option ("eval-source-map" value): errors 1`] = `Array []`;
+
+exports[`"inline" option should work with "no-fallback" value and the "devtool" option ("eval-source-map" value): result 1`] = `"{\\"postMessage\\":true,\\"onmessage\\":true}"`;
+
+exports[`"inline" option should work with "no-fallback" value and the "devtool" option ("eval-source-map" value): warnings 1`] = `Array []`;
+
 exports[`"inline" option should work with "no-fallback" value and the "devtool" option ("source-map" value): errors 1`] = `Array []`;
 
 exports[`"inline" option should work with "no-fallback" value and the "devtool" option ("source-map" value): errors 2`] = `Array []`;

--- a/test/inline-option.test.js
+++ b/test/inline-option.test.js
@@ -62,6 +62,37 @@ describe('"inline" option', () => {
     expect(getErrors(stats)).toMatchSnapshot('errors');
   });
 
+  it('should work with "no-fallback" value and the "devtool" option ("eval-source-map" value)', async () => {
+    const compiler = getCompiler(
+      './basic/entry.js',
+      { inline: 'no-fallback' },
+      { devtool: 'eval-source-map' }
+    );
+    const stats = await compile(compiler);
+    const result = await getResultFromBrowser(stats);
+    const moduleSource = getModuleSource('./basic/worker.js', stats);
+
+    expect(moduleSource.indexOf('inline.js') > 0).toBe(true);
+    expect(
+      moduleSource.indexOf('__webpack_public_path__ + "test.worker.js"') === -1
+    ).toBe(true);
+    expect(
+      moduleSource.indexOf(
+        'sourceMappingURL=data:application/json;charset=utf-8;base64,'
+      ) === -1
+    ).toBe(true);
+    expect(
+      moduleSource.indexOf(
+        '//# sourceURL=webpack-internal:///./basic/worker.js'
+      ) >= 0
+    ).toBe(true);
+    expect(stats.compilation.assets['test.worker.js']).toBeUndefined();
+    expect(stats.compilation.assets['test.worker.js.map']).toBeUndefined();
+    expect(result).toMatchSnapshot('result');
+    expect(getWarnings(stats)).toMatchSnapshot('warnings');
+    expect(getErrors(stats)).toMatchSnapshot('errors');
+  });
+
   it('should work with "no-fallback" value and the "devtool" option ("source-map" value)', async () => {
     const compiler = getCompiler(
       './basic/entry.js',

--- a/test/inline-option.test.js
+++ b/test/inline-option.test.js
@@ -71,6 +71,9 @@ describe('"inline" option', () => {
     const stats = await compile(compiler);
     const result = await getResultFromBrowser(stats);
     const moduleSource = getModuleSource('./basic/worker.js', stats);
+    const sourceUrlInternalIndex = moduleSource.indexOf(
+      'sourceURL=webpack-internal:///./basic/worker.js'
+    );
 
     expect(moduleSource.indexOf('inline.js') > 0).toBe(true);
     expect(
@@ -81,10 +84,12 @@ describe('"inline" option', () => {
         'sourceMappingURL=data:application/json;charset=utf-8;base64,'
       ) === -1
     ).toBe(true);
+    expect(sourceUrlInternalIndex >= 0).toBe(true);
     expect(
-      moduleSource.indexOf(
-        '//# sourceURL=webpack-internal:///./basic/worker.js'
-      ) >= 0
+      moduleSource.lastIndexOf('//', sourceUrlInternalIndex) >
+        moduleSource.lastIndexOf('\\n', sourceUrlInternalIndex) ||
+        moduleSource.lastIndexOf('/*', sourceUrlInternalIndex) >
+          moduleSource.lastIndexOf('*/', sourceUrlInternalIndex)
     ).toBe(true);
     expect(stats.compilation.assets['test.worker.js']).toBeUndefined();
     expect(stats.compilation.assets['test.worker.js.map']).toBeUndefined();


### PR DESCRIPTION
…comment

a sourceMappingURL comment may be created by another loader and this removes it again, but too many
characters are removed, thus uncommenting a different line that contains invalid javascript

Closes #285

<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case
See #285 
<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

