### PR TITLE
fix: serializing big strings

### DIFF
--- a/src/supportWebpack5.js
+++ b/src/supportWebpack5.js
@@ -60,17 +60,18 @@ export default function runAsChild(
           workerSource,
           options
         );
+        const workerCodeBuffer = Buffer.from(workerCode);
 
         return cache.store(
           cacheIdent,
           cacheETag,
-          workerCode,
+          workerCodeBuffer,
           (storeCacheError) => {
             if (storeCacheError) {
               return callback(storeCacheError);
             }
 
-            return callback(null, workerCode);
+            return callback(null, workerCodeBuffer);
           }
         );
       });


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

This a fix for “Serializing big strings” warning with Webpack 5 filesystem cache

### Breaking Changes

No
<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
