### PR TITLE
fix: make inline workers work from inside workers

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "webpack": "^4.0.0 || ^5.0.0"
   },
   "dependencies": {
-    "schema-utils": "^3.0.0",
-    "loader-utils": "^2.0.0"
+    "loader-utils": "^2.0.0",
+    "schema-utils": "^3.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.8",

--- a/src/runtime/inline.js
+++ b/src/runtime/inline.js
@@ -2,20 +2,21 @@
 /* eslint-disable no-undef, no-use-before-define, new-cap */
 
 module.exports = (content, workerConstructor, workerOptions, url) => {
+  const globalScope = self || window;
   try {
     try {
       let blob;
 
       try {
         // New API
-        blob = new window.Blob([content]);
+        blob = new globalScope.Blob([content]);
       } catch (e) {
         // BlobBuilder = Deprecated, but widely implemented
         const BlobBuilder =
-          window.BlobBuilder ||
-          window.WebKitBlobBuilder ||
-          window.MozBlobBuilder ||
-          window.MSBlobBuilder;
+          globalScope.BlobBuilder ||
+          globalScope.WebKitBlobBuilder ||
+          globalScope.MozBlobBuilder ||
+          globalScope.MSBlobBuilder;
 
         blob = new BlobBuilder();
 
@@ -24,15 +25,18 @@ module.exports = (content, workerConstructor, workerOptions, url) => {
         blob = blob.getBlob();
       }
 
-      const URL = window.URL || window.webkitURL;
+      const URL = globalScope.URL || globalScope.webkitURL;
       const objectURL = URL.createObjectURL(blob);
-      const worker = new window[workerConstructor](objectURL, workerOptions);
+      const worker = new globalScope[workerConstructor](
+        objectURL,
+        workerOptions
+      );
 
       URL.revokeObjectURL(objectURL);
 
       return worker;
     } catch (e) {
-      return new window[workerConstructor](
+      return new globalScope[workerConstructor](
         `data:application/javascript,${encodeURIComponent(content)}`,
         workerOptions
       );
@@ -42,6 +46,6 @@ module.exports = (content, workerConstructor, workerOptions, url) => {
       throw Error("Inline worker is not supported");
     }
 
-    return new window[workerConstructor](url, workerOptions);
+    return new globalScope[workerConstructor](url, workerOptions);
   }
 };


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix** (?)
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

This change enables inline workers to be instantiated from worker scopes (where `window` isn't available.)

### Breaking Changes

None.

### Additional Info

fixes https://github.com/webpack-contrib/worker-loader/issues/306