### PR TITLE
support node worker_thread

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -50,6 +50,8 @@ function workerGenerator(loaderContext, workerFilename, workerSource, options) {
     typeof options.esModule !== "undefined" ? options.esModule : true;
   const fnName = `${workerConstructor}_fn`;
 
+  const publicPath = options.publicPath ? JSON.stringify(options.publicPath) : '__webpack_public_path__';
+
   if (options.inline) {
     const InlineWorkerPath = stringifyRequest(
       loaderContext,
@@ -59,7 +61,7 @@ function workerGenerator(loaderContext, workerFilename, workerSource, options) {
     let fallbackWorkerPath;
 
     if (options.inline === "fallback") {
-      fallbackWorkerPath = `__webpack_public_path__ + ${JSON.stringify(
+      fallbackWorkerPath = `${publicPath} + ${JSON.stringify(
         workerFilename
       )}`;
     }
@@ -80,9 +82,13 @@ ${
     )}, ${fallbackWorkerPath});\n}\n`;
   }
 
-  return `${
+  return `${loaderContext.target === 'node'
+    ? esModule
+      ? "import {Worker} from 'worker_threads'\n"
+      : "var {Worker} = require('worker_threads')\n"
+    : ''}${
     esModule ? "export default" : "module.exports ="
-  } function ${fnName}() {\n  return new ${workerConstructor}(__webpack_public_path__ + ${JSON.stringify(
+  } function ${fnName}() {\n  return new ${workerConstructor}(${publicPath} + ${JSON.stringify(
     workerFilename
   )}${workerOptions ? `, ${JSON.stringify(workerOptions)}` : ""});\n}\n`;
 }


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Support nodejs's worker_threads out of the box.

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

### Breaking Changes

If `options.publicPath` is set, use it instead of `__webpack_public_path__`.

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info

Current, I cannot run `npm run lint`, while `npm run test:only` works. Here is the error when running `npm run lint`

```
0 info it worked if it ends with ok
1 verbose cli [
1 verbose cli   '/opt/node-v15.5.1-linux-x64/bin/node',
1 verbose cli   '/home/transang/.yarn/bin/npm',
1 verbose cli   'run',
1 verbose cli   'lint:prettier'
1 verbose cli ]
2 info using npm@6.14.8
3 info using node@v15.5.1
4 verbose run-script [ 'prelint:prettier', 'lint:prettier', 'postlint:prettier' ]
5 info lifecycle worker-loader@3.0.8~prelint:prettier: worker-loader@3.0.8
6 info lifecycle worker-loader@3.0.8~lint:prettier: worker-loader@3.0.8
7 verbose lifecycle worker-loader@3.0.8~lint:prettier: unsafe-perm in lifecycle true
8 verbose lifecycle worker-loader@3.0.8~lint:prettier: PATH: /home/transang/.config/yarn/global/node_modules/npm/node_modules/npm-lifecycle/node-gyp-bin:/home/transang/worker-loader/node_modules/.bin:/home/transang/anaconda3/bin:/home/transang/anaconda3/condabin:/opt/nvim-osx64/bin:/opt/google-cloud-sdk/bin:/opt/flutter/bin:/home/transang/.yarn/bin:/opt/helm:/opt/bin:/home/transang/go/bin:/opt/node/bin:/opt/jetbrains-toolbox:/home/transang/worker-loader/node_modules/.bin:/home/transang/.local/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/opt/cuda/bin:/opt/cuda/nsight_compute:/opt/cuda/nsight_systems/bin:/var/lib/flatpak/exports/bin:/usr/lib/jvm/default/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:/home/transang/.fzf/bin
9 verbose lifecycle worker-loader@3.0.8~lint:prettier: CWD: /home/transang/worker-loader
10 silly lifecycle worker-loader@3.0.8~lint:prettier: Args: [ '-c', 'prettier --list-different .' ]
11 silly lifecycle worker-loader@3.0.8~lint:prettier: Returned: code: 1  signal: null
12 info lifecycle worker-loader@3.0.8~lint:prettier: Failed to exec lint:prettier script
13 verbose stack Error: worker-loader@3.0.8 lint:prettier: `prettier --list-different .`
13 verbose stack Exit status 1
13 verbose stack     at EventEmitter.<anonymous> (/home/transang/.config/yarn/global/node_modules/npm/node_modules/npm-lifecycle/index.js:332:16)
13 verbose stack     at EventEmitter.emit (node:events:376:20)
13 verbose stack     at ChildProcess.<anonymous> (/home/transang/.config/yarn/global/node_modules/npm/node_modules/npm-lifecycle/lib/spawn.js:55:14)
13 verbose stack     at ChildProcess.emit (node:events:376:20)
13 verbose stack     at maybeClose (node:internal/child_process:1063:16)
13 verbose stack     at Process.ChildProcess._handle.onexit (node:internal/child_process:295:5)
14 verbose pkgid worker-loader@3.0.8
15 verbose cwd /home/transang/worker-loader
16 verbose Linux 5.11.10-arch1-1
17 verbose argv "/opt/node-v15.5.1-linux-x64/bin/node" "/home/transang/.yarn/bin/npm" "run" "lint:prettier"
18 verbose node v15.5.1
19 verbose npm  v6.14.8
20 error code ELIFECYCLE
21 error errno 1
22 error worker-loader@3.0.8 lint:prettier: `prettier --list-different .`
22 error Exit status 1
23 error Failed at the worker-loader@3.0.8 lint:prettier script.
23 error This is probably not a problem with npm. There is likely additional logging output above.
24 verbose exit [ 1, true ]
```