### PR TITLE
fix: make inline workers work from IE/Edge legacy

### DIFF
--- a/src/runtime/inline.js
+++ b/src/runtime/inline.js
@@ -32,7 +32,13 @@ module.exports = (content, workerConstructor, workerOptions, url) => {
         workerOptions
       );
 
-      URL.revokeObjectURL(objectURL);
+      // URL.revokeObjectUrl shouldn't be called immediately after Worker creation on IE and Edge legacy.
+      // Worker will be forked but the script will not be executed and there are no error event or runtime exceptions for this.
+      if (globalScope.setImmediate) {
+        globalScope.setImmediate(() => URL.revokeObjectURL(objectURL));
+      } else {
+        URL.revokeObjectURL(objectURL);
+      }
 
       return worker;
     } catch (e) {


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

- Fix inline worker to work on IE11 and Edge legacy.
- This PR will resolve an issue #292.

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

No breaking changes.

### Additional Info

N/A