### PR TITLE
TypeScript: loading worker module more simply

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,7 +455,7 @@ To integrate with TypeScript, you will need to define a custom module for the ex
 **typings/worker-loader.d.ts**
 
 ```typescript
-declare module "worker-loader!*" {
+declare module "*.worker.ts" {
   // You need to change `Worker`, if you specified a different value for the `workerType` option
   class WebpackWorker extends Worker {
     constructor();
@@ -482,14 +482,39 @@ ctx.addEventListener("message", (event) => console.log(event));
 **index.ts**
 
 ```typescript
-import Worker from "worker-loader!./Worker";
+import MyWorker from "./my.worker.ts";
 
-const worker = new Worker();
+const worker = new MyWorker();
 
 worker.postMessage({ a: 1 });
 worker.onmessage = (event) => {};
 
 worker.addEventListener("message", (event) => {});
+```
+
+**webpack.config.js**
+
+```js
+module.exports = {
+  module: {
+    rules: [
+      // Place this *before* the `ts-loader`.
+      {
+        test: /\.worker\.ts$/,
+        loader: 'worker-loader',
+      },
+      {
+        test: /\.ts$/,
+        loader: 'ts-loader',
+      },
+    ],
+  },
+  resolve: {
+    extensions: [
+      '.ts', '.js',
+    ],
+  },
+};
 ```
 
 ### Cross-Origin Policy

--- a/README.md
+++ b/README.md
@@ -452,6 +452,53 @@ module.exports = {
 
 To integrate with TypeScript, you will need to define a custom module for the exports of your worker.
 
+#### Loading with `worker-loader!`
+
+**typings/worker-loader.d.ts**
+
+```typescript
+declare module "worker-loader!*" {
+  // You need to change `Worker`, if you specified a different value for the `workerType` option
+  class WebpackWorker extends Worker {
+    constructor();
+  }
+
+  // Uncomment this if you set the `esModule` option to `false`
+  // export = WebpackWorker;
+  export default WebpackWorker;
+}
+```
+
+**my.worker.ts**
+
+```typescript
+const ctx: Worker = self as any;
+
+// Post data to parent thread
+ctx.postMessage({ foo: "foo" });
+
+// Respond to message from parent thread
+ctx.addEventListener("message", (event) => console.log(event));
+```
+
+**index.ts**
+
+```typescript
+import Worker from "worker-loader!./Worker";
+
+const worker = new Worker();
+
+worker.postMessage({ a: 1 });
+worker.onmessage = (event) => {};
+
+worker.addEventListener("message", (event) => {});
+```
+
+#### Loading without `worker-loader!`
+
+Alternatively, you can ommit the `worker-loader!` prefix passed to `import` statement by using the following notation.
+This is useful for executing the code using a non-WebPack runtime environment (such as Node.js with `WebWorker` polyfills).
+
 **typings/worker-loader.d.ts**
 
 ```typescript

--- a/README.md
+++ b/README.md
@@ -497,7 +497,8 @@ worker.addEventListener("message", (event) => {});
 #### Loading without `worker-loader!`
 
 Alternatively, you can ommit the `worker-loader!` prefix passed to `import` statement by using the following notation.
-This is useful for executing the code using a non-WebPack runtime environment (such as Node.js with `WebWorker` polyfills).
+This is useful for executing the code using a non-WebPack runtime environment
+(such as Jest with [`workerloader-jest-transformer`](https://github.com/astagi/workerloader-jest-transformer)).
 
 **typings/worker-loader.d.ts**
 


### PR DESCRIPTION
I found a simpler notation for TypeScript.

In this modification, the `worker-module!` prefix passed to `import` statement is not required anymore.

----

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

The `worker-module!` prefix originates from WebPack and which causes a compile error on non-WebPack systems.
This makes hard to test the code directly using testing frameworks such as Jest.

(Note: most testing frameworks only work with Node.js and do not support WebWorker. You should polyfill it using some utilities such as [https://github.com/astagi/workerloader-jest-transformer](workerloader-jest-transformer).)

### Breaking Changes

TypeScript notation simplified.

### Additional Info

cf: https://github.com/EllipticPIR/libepir/commit/f328396d85c5421f52ee623fb64a679e3687e457
